### PR TITLE
ensuring latest version of corepack to avoid key signing issue

### DIFF
--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-slim AS dependencies
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && npm install -g corepack@latest
 COPY package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile


### PR DESCRIPTION
Error was due to this issue: https://github.com/pnpm/pnpm/issues/9029

Opted to go with this comment's advice: https://github.com/pnpm/pnpm/issues/9029#issuecomment-2631400936

Was able to determine this by running the command included in `start.sh` manually AND removing the `nohup` part so I could see the full output of the command directly. So specifically, I ran: 
```bash
(cd ./doodlebot.media.mit.edu && sudo ./cli/prod.sh)
```
Which then gave the following output: 
```
=> ERROR [frontend dependencies 5/5] RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile                                                1.0s
------                                                                                                                                                                     
 > [frontend dependencies 5/5] RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile:                                                           
0.685 /usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21535                                                                                                     
0.685   if (key == null || signature == null) throw new Error(`Cannot find matching keyid: ${JSON.stringify({ signatures, keys })}`);                                      
0.685                                               ^                                                                                                                      
0.685                                                                                                                                                                      
0.685 Error: Cannot find matching keyid: {"signatures":[{"sig":"MEQCIBfxS9RKPsi46jxBHnsGYQ03mg8um110415vE6KRCzY8AiBvik66sYxJ/NyCovwJSbDuuoaYCxc7EVdFhaaciIXjTw==","keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"}],"keys":[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}]}     
0.685     at verifySignature (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21535:47)                                                                         
0.685     at fetchLatestStableVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21553:5)                                                                 
0.685     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)                                                                                    
0.685     at async fetchLatestStableVersion2 (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21672:14)
0.685     at async Engine.getDefaultVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22292:23)
0.685     at async Engine.executePackageManagerRequest (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22390:47)
0.685     at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23096:5)
0.686 
0.686 Node.js v20.18.2
------
```
Some googling led to me to a github issue that then led me to the one linked above. 